### PR TITLE
adds button to copy base64 encoded text to clipboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "source": "src/index.html",
   "scripts": {
     "// run from a separate build dir, so that 'dist' does not interfere with this": "",
-    "start": "parcel --dist-dir build",
+    "start": "parcel --https --dist-dir build",
     "// Create a 'dist' directory that can be deployed to a server (or just open dist/index.html in IDEA with Open in -> Browser)": "",
     "dist": "run-s check clean:dist assemble",
     "assemble": "parcel build --public-url ./",

--- a/src/Base64.tsx
+++ b/src/Base64.tsx
@@ -44,6 +44,13 @@ function Base64(): JSX.Element {
         setSeparatedLines(newSeparatedLines)
     }
 
+    function copyBase64ToClipboard(): void {
+        navigator
+            .clipboard
+            .writeText(encodeTextInput())
+            .catch(() => console.warn("Failed to copy to clipboard"))
+    }
+
     return (
         <form id="base64">
             <header>Base 64 Encoder</header>
@@ -83,6 +90,8 @@ function Base64(): JSX.Element {
                       value={encodeTextInput()}
                       readonly
                       spellcheck={false}/>
+
+            {navigator?.clipboard?.writeText && <button id="copy-to-clipboard" type="button" onClick={copyBase64ToClipboard}>Copy to Clipboard</button>}
         </form>
     );
 }

--- a/src/base64.sass
+++ b/src/base64.sass
@@ -33,3 +33,7 @@
 
   #base64-output
     background-color: #eee
+
+  #copy-to-clipboard
+    grid-column: 3 / 4
+    justify-self: flex-end

--- a/src/main.sass
+++ b/src/main.sass
@@ -11,3 +11,12 @@ body
 label
   cursor: default
 
+button
+  cursor: default
+  border: 1px solid #999
+  border-radius: 4px
+  padding: 2px 6px
+  text-align: center
+
+  &:hover
+    background-color: #eee


### PR DESCRIPTION
Also added --https option to parcel command in "start" because on Safari the clipboard can only be accessed in https context.
Styling left for a later ticket.